### PR TITLE
First pass at inline deployment metrics on pipelines

### DIFF
--- a/app/scripts/directives/metrics.js
+++ b/app/scripts/directives/metrics.js
@@ -13,7 +13,12 @@ angular.module('openshiftConsole')
       scope: {
         // Either pod or deployment must be set
         pod: '=?',
-        deployment: '=?'
+        deployment: '=?',
+        hideTimeRangeSelect: '=?',
+        hideLabels: '=?',
+        hideAxis: '=?',
+        sparklineWidth: '=?',
+        sparklineHeight: '=?'
       },
       templateUrl: 'views/directives/metrics.html',
       link: function(scope) {
@@ -145,7 +150,7 @@ angular.module('openshiftConsole')
             bindto: '#' + metric.chartPrefix + scope.uniqueID + '-sparkline',
             axis: {
               x: {
-                show: true,
+                show: !scope.hideAxis,
                 type: 'timeseries',
                 // With default padding you can have negative axis tick values.
                 padding: {
@@ -158,6 +163,7 @@ angular.module('openshiftConsole')
                 }
               },
               y: {
+                show: !scope.hideAxis,
                 label: metric.units,
                 min: 0,
                 // With default padding you can have negative axis tick values.
@@ -166,7 +172,6 @@ angular.module('openshiftConsole')
                   top: 0,
                   bottom: 0
                 },
-                show: true,
                 tick: {
                   format: function(value) {
                     return d3.round(value, 2);
@@ -175,13 +180,14 @@ angular.module('openshiftConsole')
               }
             },
             legend: {
-              show: metric.datasets.length > 1
+              show: metric.datasets.length > 1 && !scope.hideLabels
             },
             point: {
               show: false
             },
             size: {
-              height: 160
+              height: scope.sparklineHeight || 160,
+              width: scope.sparklineWidth || undefined,
             }
           };
         };

--- a/app/views/_overview-service.html
+++ b/app/views/_overview-service.html
@@ -49,6 +49,7 @@
           <div row mobile="column" class="deployment-block">
             <div
                  column
+                 grow="3"
                  ng-if="!(pipelinesByDeployment[deployment.metadata.name] | isIncompleteBuild)"
                  class="deployment-details">
               <deployment-pipeline-details

--- a/app/views/directives/deployment-pipeline-details.html
+++ b/app/views/directives/deployment-pipeline-details.html
@@ -10,8 +10,12 @@
           Replication Controller {{deployment.metadata.name}}
         </h3>
       </div>
-      <pod-template
-        pod-template="deployment.spec.template">
-      </pod-template>
+
+      <metrics deployment="deployment"
+          hide-time-range-select="true"
+          hide-labels="true"
+          hide-axis="true"
+          sparkline-width="200"
+          sparkline-height="50"></metrics>
   </div>
 </div>

--- a/app/views/directives/metrics.html
+++ b/app/views/directives/metrics.html
@@ -15,7 +15,7 @@
         </select>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" ng-if="!hideTimeRangeSelect">
       <label for="timeRange">Time Range:</label>
       <select id="timeRange"
               ng-model="options.timeRange"
@@ -46,7 +46,7 @@
   </div>
 
   <div ng-repeat="metric in metrics" ng-if="anyUsageByMetric(metric) && !metricsError">
-    <h3>
+    <h3 ng-if="!hideLabels">
       {{metric.label}}
       <small ng-if="pod.spec.containers.length > 1">
         <span ng-if="metric.containerMetric">Container Metrics</span>


### PR DESCRIPTION
@spadgett First pass at adding deployment metrics inline in pipelines. We will need more directive options to customize how the metrics are displayed when inline, filter to only display a given chart, etc. I'm considering, instead of having multiple `hide-this-and-that=true` directive parameters, maybe add a `profile=inline`, `profile=regular` or something similar. Completely different directives for both regular and inline metrics might also be considered.
