### PR TITLE
Updates to overview deployments animation

### DIFF
--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -282,7 +282,6 @@
 
 .deployment-donut {
   justify-content: center;
-  margin-right: 10px;
   min-width: 200px;
   .scaling-controls {
     justify-content: center;

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -3,36 +3,9 @@
 @shield-bgcolor:       #ebebeb;
 @shield-border-color:  @overview-border-gray;
 @shield-width:         36px;
+@shield-width-lg:      50px;
 
-// fadeSlideOut
-@keyframes fadeSlideOut {
-  0% { opacity: 1; }
-  100% { opacity: 0; margin-left: -350px; }
-}
-@-webkit-keyframes fadeSlideOut {
-  0% { opacity: 1; }
-  100% { opacity: 0; margin-left: -350px; }
-}
 
-// fadeIn
-@keyframes fadeIn {
-  0% { opacity: 0; }
-  100% { opacity: 1; }
-}
-@-webkit-keyframes fadeIn {
-  0% { opacity: 0; }
-  100% { opacity: 1; }
-}
-
-// fadeOut
-@keyframes fadeOut {
-  0% { opacity: 1; }
-  100% { opacity: 0; }
-}
-@-webkit-keyframes fadeOut {
-  0% { opacity: 1; }
-  100% { opacity: 0; }
-}
 
 .overview {
   font-weight: 300;
@@ -133,7 +106,7 @@
   }
   .service-group-header {
     cursor: pointer;
-    justify-content: space-between;
+    .justify-content(@justify: space-between);
     padding: 10px;
     .route-title {
       line-height: 1.4;
@@ -159,7 +132,7 @@
   .overview-pipeline {
     border-top-width: 0;
     .overview-pipeline-details {
-      flex-wrap: wrap;
+      .flex-wrap(@wrap: nowrap);
     }
     .build-name, .build-phase {
       padding: 5px 10px;
@@ -201,15 +174,21 @@
   }
   .service-group-body {
     border-top-width: 0;
-    margin-top: 10px;
+    overflow: hidden;
     padding: 0;
     .overview-services {
-      flex-wrap: wrap;
+      .flex-wrap(@wrap: nowrap);
       // Put margins between the services, but make them flush with the left
       // border even when they wrap.
-      margin-left: -10px;
+      margin-left: -11px;
+      overview-service {
+        max-width: 50%;
+        min-width: 50%;
+      }
       .deployment-tile {
         margin-left: 10px;
+        margin-top: 10px;
+        position: relative;
       }
     }
 
@@ -239,21 +218,21 @@
     text-transform: uppercase;
   }
   .build-pipeline {
-    flex: 1;
+    .flex(@columns: 1 1 0%);
     // Avoid double borders inside the panel.
     margin: -1px;
     .build-summary {
-      flex-grow: 1;
+      .flex-grow(@grow: 1);
       @media (min-width: @screen-md-min) {
-        flex-grow: 0;
+        .flex-grow(@grow: 0);
       }
     }
   }
   .service-title {
     .text-muted();
-    align-items: flex-end;
+    .align-items(@align: flex-end);
     border-bottom: 1px solid @overview-border-gray;
-    justify-content: space-between;
+    .justify-content(@justify: space-between);
     padding: 5px 10px;
   }
   .deployment-tile {
@@ -267,18 +246,21 @@
       padding: 5px 10px;
     }
     .deployment-body {
-      flex-direction: column;
+      .flex-direction(@direction: column);
       padding: 10px;
+      min-height: 227px;
+      position: relative;
       .deployment-donut {
-        align-items: center;
+        .align-items(@align: center);
       }
       @media (min-width: @screen-md-min) {
-        flex-direction: row;
-        justify-content: space-between;
+        .flex-direction(@direction: row);
+        .justify-content(@justify: flex-end);
+        min-height: 164px;
       }
     }
-    .overview-donut {
-      align-items: center;
+    .overview-donut, .overview-metrics {
+      .align-items(@align: center);
     }
     .overview-metrics {
       @media (max-width: @screen-sm-max) {
@@ -286,40 +268,72 @@
         .text-center();
       }
     }
+    .overview-donut-connector {
+      text-align: center; 
+    }
+    
+    // fadeSlideOut
+    @keyframes fadeSlideOut {
+      0% { opacity: 1; }
+      50% { opacity: 0; }
+      100% { opacity: 0; 
+        margin-left: -300px; }
+    }
+
+    @keyframes flexGrow {
+      to {
+        .flex-basis(@width: 0%);
+        .flex-grow(@grow: 1);
+        .flex-shrink(@shrink: 1);
+      }
+    }
+    
     @media (min-width: @screen-md-min) {
       .deployment-details {
-        margin-left: 15px;
-        order: 1;
+        .align-items(@align: flex-start);
+        .flex(@columns: 1 1 0%);
+        padding-left: 30px;
+        max-width: 50%;
+        .flex-order(@order: 1);
         &.ng-leave {
-          animation: fadeSlideOut 1s ease forwards;
+          animation: fadeSlideOut .75s ease forwards; // Needs to be faster than flexGrow
         }
       }
       .overview-donut {
-        order: 2;
-        &.ng-appear {
-          animation: fadeIn 1s ease forwards;
-        }
+        .flex(@columns: 1 1 0%);
+        overflow: hidden; 
+        .flex-order(@order: 2);
+        max-width: 50%;
+        min-height: 150px;
         &.latest {
-          order: 4;
+          .flex-order(@order: 4);
+          :last-child.latest.ng-animate {
+            /* 0 does not work so we have to use a small number */
+            .flex-basis(@width: 1);
+            .flex-grow(@grow: 0.00001);
+            .flex-shrink(@shrink: 1);
+            animation: flexGrow 1s ease forwards;
+          }
         }
       }
       .overview-donut-connector {
-        order: 3;
+        .flex-order(@order: 3);
         font-size: 300%;
         color: #ccc;
-        align-items: center;
+        .align-items(@align: center);
+        .justify-content(@justify: center);
         line-height: 1;
         div {
           text-align: center;
         }
         .finishing-deployment-text {
           font-size: 18px;
-          margin: 0 30px;
+          text-align: center;
         }
       }
       .overview-unsuccessful-state {
-        order: 3;
-        align-items: center;
+        .flex-order(@order: 3);
+        .align-items(@align: center);
         line-height: 1;
         .unsuccessful-state-text {
           font-size: 18px;
@@ -340,9 +354,10 @@
     .text-center();
     .text-muted();
     .well();
-    justify-content: center;
+    .justify-content(@justify: center);
     margin-left: 5px;
     margin-bottom: 0;
+
     padding: 30px;
     // .blank-state-icon {
     //   font-size: 60px;
@@ -366,16 +381,19 @@
     border-bottom: 0;
     width: @shield-width;
     position: absolute;
-    align-items: center;
+    .align-items(@align: center);
     right: 15px;
     top: -1px;
+    z-index: 9;
     .shield-number {
-      display: flex;
+      .flex-display(@display: flex);
+      font-size: 11px;
+      font-weight: 500;
       height: 30px;
       position: relative;
       width: @shield-width;
-      align-items: center;
-      justify-content: center;
+      .align-items(@align: center);
+      .justify-content(@justify: center);
     }
     .shield-number:before {
       border-left: (@shield-width / 2) solid transparent;
@@ -398,6 +416,15 @@
       position: absolute;
       bottom: -9px;
       width: 0;
+    }
+    // Use if deployments > 999
+    &.shield-lg {
+      width: @shield-width-lg;
+      .shield-number {width: @shield-width-lg;}
+      .shield-number:before, .shield-number:after {
+        border-left: (@shield-width-lg / 2) solid transparent;
+        border-right: (@shield-width-lg / 2) solid transparent;
+      }
     }
   }
 }

--- a/app/views/directives/deployment-donut.html
+++ b/app/views/directives/deployment-donut.html
@@ -1,4 +1,4 @@
-<div column class="deployment-donut" ng-show="pods">
+<div column class="deployment-donut">
   <div row>
     <div column>
       <pod-donut


### PR DESCRIPTION
```
- switch flex rules to use flexbox mixins
- addition of .shield-lg to use when >999 deployments
- remove ng-show="pods" so new deployment donut displays immediately
```
