### PR TITLE
Fixing incorrect alert margin

### DIFF
--- a/app/styles/_list-pf.less
+++ b/app/styles/_list-pf.less
@@ -18,13 +18,11 @@
 
 .list-pf-content {
   flex-grow: 1;
-  .alert {
-    &:first-child {
-      margin-top: 0;
-    }
-    &:last-child {
-      margin-bottom: 20px;
-    }
+  .alert:first-child {
+    margin-top: 0;
+  }
+  .alert-wrapper:last-child {
+    margin-bottom: 20px;
   }
   .list-pf-chevron + & {
     align-items: center;


### PR DESCRIPTION
@spadgett 

And I found an additional bug with

```
  .build-pipeline-wrapper {
    margin-bottom: 20px;
  }
```

in _overview.less that I didn't have time to fully fix.  Essentially, any time there is more than one pipeline displayed (one complete, one in progress), the aforementioned rule applies because of the ng-repeat.  There should be no margin between pipeline rows.