### PR TITLE
Bug fix for long, unbroken strings in tooltips

### DIFF
--- a/app/styles/_tooltip.less
+++ b/app/styles/_tooltip.less
@@ -1,0 +1,7 @@
+//
+// Tooltips
+// --------------------------------------------------
+
+.tooltip-inner {
+  .word-break(); // so that long, unbroken strings don't overflow
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -36,6 +36,7 @@
 @import "_tables.less";
 @import "_tile.less";
 @import "_toast.less";
+@import "_tooltip.less";
 @import "_topology.less";
 @import "_typography.less";
 @import "_spacers.less";


### PR DESCRIPTION
Before

![screen shot 2017-03-14 at 9 50 53 am](https://cloud.githubusercontent.com/assets/895728/23963460/bd90d97c-0987-11e7-91c4-cd54dd296258.PNG)

After

![screen shot 2017-03-15 at 1 57 00 pm](https://cloud.githubusercontent.com/assets/895728/23963479/c7874fc4-0987-11e7-90a6-828a723a692f.PNG)

Note this is a general fix for tooltips anywhere in the UI.

@spadgett 