### PR TITLE
Adjustments to fix IE11 vertical-nav icon alignment

### DIFF
--- a/app/styles/_vertical-nav.less
+++ b/app/styles/_vertical-nav.less
@@ -59,16 +59,13 @@
         height: auto;
         padding: 10px 15px;
       }
-      // remove margin from icon that causes shifting when toggled
       .fa, .pficon {
         font-size: (@font-size-base + 2);
-        margin-right: 0;
         @media(min-width: @screen-sm-min) {
           font-size: (@font-size-base + 5);
         }
       }
       .list-group-item-value {
-        margin-left: 10px;
         text-decoration: none !important;
       }
     }
@@ -91,9 +88,6 @@
     // right arrow alignment
     > a:after {
       font-size: 14px;
-      top: initial;
-      padding: 0;
-      line-height: inherit;
     }
   }
   .nav-pf-secondary-nav {


### PR DESCRIPTION
<img width="457" alt="screen shot 2017-08-22 at 5 22 47 pm" src="https://user-images.githubusercontent.com/1874151/29588309-fe8a21cc-875e-11e7-93d7-a9a7813420bc.png">
